### PR TITLE
Handle FP16 warning on CPU

### DIFF
--- a/transcribe_summary.py
+++ b/transcribe_summary.py
@@ -169,9 +169,10 @@ def transcribe(audio_path: str, model_name: str, method: str, api_key: Optional[
             shutil.rmtree(TEMP_DIR, ignore_errors=True)
     else:
         import whisper
+        import torch
 
         model = whisper.load_model(model_name)
-        result = model.transcribe(audio_path)
+        result = model.transcribe(audio_path, fp16=torch.cuda.is_available())
         return result["text"].strip()
 
 


### PR DESCRIPTION
## Summary
- Avoid FP16 warning by toggling fp16 based on CUDA availability

## Testing
- `python -m py_compile transcribe_summary.py batch_transcribe.py`


------
https://chatgpt.com/codex/tasks/task_b_688f2cfaf9908333af470bf2a0309490