### PR TITLE
Add runtime config handling for bundled builds

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -20,7 +20,13 @@ class TranscribeGUI:
         master.title("gpt_transcribe")
         master.resizable(False, False)
 
-        self.config = transcribe_summary.load_config(CONFIG_PATH)
+        try:
+            self.config = transcribe_summary.load_config(CONFIG_PATH)
+        except FileNotFoundError as e:
+            messagebox.showerror("Configuration", str(e))
+            master.destroy()
+            return
+        transcribe_summary.ensure_prompt(PROMPT_PATH)
         prompt_text = transcribe_summary._load_text(PROMPT_PATH)
 
         # Configuration fields


### PR DESCRIPTION
## Summary
- support PyInstaller bundles by detecting `_MEIPASS` and separating resource and user dirs
- generate `config.cfg` from bundled template when missing and ensure `summary_prompt.txt`
- handle missing config gracefully in GUI and copy prompt file out of bundle

## Testing
- `python -m py_compile transcribe_summary.py gui.py`
- `python - <<'PY'
import transcribe_summary
from pathlib import Path
try:
    transcribe_summary.load_config()
except FileNotFoundError as e:
    print('raised:', e)
print('config exists?', (Path(transcribe_summary.BASE_DIR) / transcribe_summary.CONFIG_FILE).exists())
print('prompt exists?', (Path(transcribe_summary.BASE_DIR) / transcribe_summary.PROMPT_FILE).exists())
PY`


------
https://chatgpt.com/codex/tasks/task_b_68907c9659d083339926b0a1696675fa