### PR TITLE
bundle dependencies in build scripts

### DIFF
--- a/build_windows.bat
+++ b/build_windows.bat
@@ -1,6 +1,9 @@
 @echo off
 REM Build standalone executable and Inno Setup installer for gpt_transcribe
 
+pip install -r requirements.txt || goto :error
+pip install pyinstaller || goto :error
+
 pyinstaller gui.py --name gpt_transcribe --noconsole --onefile --add-data "config.template.cfg;." --add-data "summary_prompt.txt;." --add-data "README.md;." --icon logo/logo.ico || goto :error
 
 iscc gpt_transcribe.iss


### PR DESCRIPTION
## Summary
- revert to bundling Python requirements
- build scripts install dependencies and PyInstaller before packaging

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_6890d9330a888333ab2ff5f2b6dad64d