### PR TITLE
Bundle ffmpeg and build Flatpak

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import tkinter as tk
 from tkinter import filedialog, messagebox, scrolledtext
 from tkinter import ttk

--- a/io.github.gpt_transcribe.yaml
+++ b/io.github.gpt_transcribe.yaml
@@ -1,0 +1,38 @@
+app-id: io.github.gpt_transcribe
+runtime: org.freedesktop.Platform
+runtime-version: "23.08"
+sdk: org.freedesktop.Sdk
+command: gpt_transcribe
+finish-args:
+  - --share=network
+  - --socket=x11
+modules:
+  - name: python-deps
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-cache-dir --prefix=/app -r requirements.txt
+    sources:
+      - type: file
+        path: requirements.txt
+  - name: ffmpeg
+    buildsystem: simple
+    sources:
+      - type: archive
+        url: https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
+        sha256: abda8d77ce8309141f83ab8edf0596834087c52467f6badf376a6a2a4c87cf67
+        strip-components: 1
+    build-commands:
+      - install -Dm755 ffmpeg /app/bin/ffmpeg
+      - install -Dm755 ffprobe /app/bin/ffprobe
+  - name: gpt_transcribe
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 gui.py /app/bin/gpt_transcribe
+      - install -Dm644 transcribe_summary.py /app/bin/transcribe_summary.py
+      - install -Dm644 summary_prompt.txt /app/bin/summary_prompt.txt
+      - install -Dm644 config.template.cfg /app/bin/config.template.cfg
+      - install -Dm644 README.md /app/bin/README.md
+      - install -Dm644 logo/logo.png /app/share/icons/hicolor/256x256/apps/io.github.gpt_transcribe.png
+    sources:
+      - type: dir
+        path: .


### PR DESCRIPTION
## Summary
- Include static ffmpeg and resource files in AppImage build; add Flatpak packaging to build script.
- Add shebang to `gui.py` to allow executing as a script.
- Provide Flatpak manifest to bundle Python deps and ffmpeg.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6891079028d48333ad5f353b9026d5d6