### PR TITLE
Allow network during flatpak build for dependencies

### DIFF
--- a/io.github.gpt_transcribe.yaml
+++ b/io.github.gpt_transcribe.yaml
@@ -9,6 +9,9 @@ finish-args:
 modules:
   - name: python-deps
     buildsystem: simple
+    build-options:
+      build-args:
+        - --share=network
     build-commands:
       - pip3 install --no-cache-dir --prefix=/app -r requirements.txt
     sources:


### PR DESCRIPTION
## Summary
- enable network access when installing Python dependencies in Flatpak build

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68911e035ed48333affbb57e306db186