### PR TITLE
Optimize flatpak build cache removal

### DIFF
--- a/build_appimage.sh
+++ b/build_appimage.sh
@@ -93,7 +93,12 @@ echo "✅ Fertig: AppImage erstellt unter ${OUTPUT_APPIMAGE}"
 
 # === Flatpak erstellen ===
 echo "📦 Erstelle Flatpak ..."
-flatpak-builder --repo=repo --force-clean build-dir ${FLATPAK_MANIFEST}
+flatpak-builder \
+    --repo=repo \
+    --force-clean \
+    --delete-build-dirs \
+    --disable-cache \
+    build-dir ${FLATPAK_MANIFEST}
 flatpak build-bundle repo gpt_transcribe.flatpak io.github.gpt_transcribe
 echo "✅ Fertig: Flatpak erstellt unter gpt_transcribe.flatpak"
 


### PR DESCRIPTION
## Summary
- speed up flatpak build cleanup by disabling cache and deleting build directories

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_68912f82e8708333b4ae59b11975186e