### PR TITLE
Add macOS build script and update README for macOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # gpt_transcribe
 
 Transcribe audio files with Whisper and summarize the result using a chat model.
-The script runs on both Linux and Windows.
+The script runs on Linux, macOS, and Windows.
 
 ## Installation
 
 1. Install Python 3.8 or newer.
 2. Install [ffmpeg](https://ffmpeg.org/).
    - Linux: `sudo apt install ffmpeg`
+   - macOS: `brew install ffmpeg`
    - Windows: download a build from the ffmpeg website and add it to your `PATH`.
 3. (Optional) Create and activate a virtual environment:
    - Linux/macOS: `python3 -m venv .venv && source .venv/bin/activate`
@@ -20,6 +21,14 @@ The script runs on both Linux and Windows.
 
 ```bash
 sudo apt update && sudo apt install python3-venv ffmpeg
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### macOS
+
+```bash
+brew install python3 ffmpeg
 python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 ```
@@ -129,6 +138,18 @@ The resulting binary in `dist/` can be executed directly or packaged as shown be
 3. Commit and push your changes, then create a GitHub release. Upload the generated
    installer or `dist\gpt_transcribe.exe` so others can download it.
 
+## Creating a macOS app and DMG
+
+A helper script `build_macos.sh` builds a standalone binary and packs it into a
+compressed disk image:
+
+```bash
+./build_macos.sh
+```
+
+The script installs packages from `requirements.txt`, installs PyInstaller and
+creates `dist/gpt_transcribe` and `dist/gpt_transcribe.dmg`.
+
 ## Creating a Linux AppImage
 
 A helper script `build_appimage.sh` builds an AppImage with all Python dependencies.
@@ -138,7 +159,8 @@ A helper script `build_appimage.sh` builds an AppImage with all Python dependenc
 ```
 
 The script installs packages from `requirements.txt`, installs PyInstaller and
-downloads `appimagetool` if needed. The resulting AppImage is placed in `dist/`.
+downloads `appimagetool` if needed. It produces both the AppImage and a
+`gpt_transcribe.flatpak` bundle, placing all artifacts in `dist/`.
 
 ## Creating a Flatpak
 

--- a/build_appimage.sh
+++ b/build_appimage.sh
@@ -16,7 +16,8 @@ FLATPAK_MANIFEST="io.github.gpt_transcribe.yaml"
 DIST_DIR="./dist"
 APPDIR="${APP_NAME}.AppDir"
 OUTPUT_APPIMAGE="${DIST_DIR}/${APP_NAME}-x86_64.AppImage"
-DISABLE_CACHE=${DISABLE_CACHE:-0}  # set to 1 to force flatpak-builder to prune its cache
+OUTPUT_FLATPAK="${DIST_DIR}/gpt_transcribe.flatpak"
+DISABLE_CACHE=${DISABLE_CACHE:-1}  # set to 0 to reuse flatpak-builder cache
 
 echo "📦 Starte AppImage-Build für $DISPLAY_NAME"
 
@@ -95,7 +96,7 @@ echo "✅ Fertig: AppImage erstellt unter ${OUTPUT_APPIMAGE}"
 # === Flatpak erstellen ===
 echo "📦 Erstelle Flatpak ..."
 if [ "$DISABLE_CACHE" = "1" ]; then
-    echo "⚠️  Cache deaktiviert – dies kann länger dauern"
+    echo "⚠️  Cache deaktiviert – 'Pruning cache' wird übersprungen"
     flatpak-builder \
         --repo=repo \
         --force-clean \
@@ -109,8 +110,8 @@ else
         --force-clean \
         build-dir ${FLATPAK_MANIFEST}
 fi
-flatpak build-bundle repo gpt_transcribe.flatpak io.github.gpt_transcribe
-echo "✅ Fertig: Flatpak erstellt unter gpt_transcribe.flatpak"
+flatpak build-bundle repo "${OUTPUT_FLATPAK}" io.github.gpt_transcribe
+echo "✅ Fertig: Flatpak erstellt unter ${OUTPUT_FLATPAK}"
 
 # === Testen (optional) ===
 echo "🚀 Starte Testlauf des AppImages ..."

--- a/build_macos.sh
+++ b/build_macos.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# Build standalone macOS binary and DMG for gpt_transcribe
+
+pip3 install -r requirements.txt
+pip3 install pyinstaller
+
+pyinstaller gui.py --name gpt_transcribe --noconsole --onefile \
+    --add-data "config.template.cfg:." \
+    --add-data "summary_prompt.txt:." \
+    --add-data "README.md:."
+
+# Create a compressed disk image containing the build
+mkdir -p dist
+rm -f dist/gpt_transcribe.dmg
+hdiutil create -volname gpt_transcribe -srcfolder dist \
+    -ov -format UDZO dist/gpt_transcribe.dmg


### PR DESCRIPTION
## Summary
- add `build_macos.sh` to build a standalone macOS binary and DMG
- document macOS installation steps and build instructions
- move generated Flatpak bundle into `dist` and disable Flatpak builder cache by default

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6891bded6f848333a620ba12bdc5f857