### PR TITLE
Include Tkinter runtime, use audioop-lts fallback, and log AppImage build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,6 +217,8 @@ audio/*
 !audio/.gitkeep
 output/*
 !output/.gitkeep
+logs/*
+!logs/.gitkeep
 temp/
 inno_setup.iss
 packages/

--- a/io.github.gpt_transcribe.yaml
+++ b/io.github.gpt_transcribe.yaml
@@ -2,16 +2,23 @@ app-id: io.github.gpt_transcribe
 runtime: org.freedesktop.Platform
 runtime-version: "23.08"
 sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.python3-tkinter
 command: gpt_transcribe
 finish-args:
   - --share=network
   - --socket=x11
+  - --env=PYTHONPATH=/app/lib/python3.11/site-packages:/usr/lib/sdk/python3-tkinter/lib/python3.11/site-packages
+  - --env=LD_LIBRARY_PATH=/usr/lib/sdk/python3-tkinter/lib
 modules:
   - name: python-deps
     buildsystem: simple
     build-options:
       build-args:
         - --share=network
+      env:
+        PYTHONPATH: /app/lib/python3.11/site-packages:/usr/lib/sdk/python3-tkinter/lib/python3.11/site-packages
+        LD_LIBRARY_PATH: /usr/lib/sdk/python3-tkinter/lib
     build-commands:
       - pip3 install --no-cache-dir --prefix=/app -r requirements.txt
     sources:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 openai>=1.0.0
 pydub
+audioop-lts; python_version >= "3.13"
 reportlab
 
 openai-whisper


### PR DESCRIPTION
## Summary
- add python3-tkinter Flatpak SDK extension and related environment
- prefer `audioop-lts` over deprecated `pyaudioop`, installing it when the stdlib `audioop` module is missing
- declare `audioop-lts` as a conditional Python dependency for future Flatpak builds
- capture AppImage build script output in `logs/build_appimage.log`
- auto-install the `python3-tkinter` Flatpak extension during AppImage/Flatpak build

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6891cec6410083339e420a8a0f034483