### PR TITLE
Fix Flatpak build dependencies

### DIFF
--- a/build_appimage.sh
+++ b/build_appimage.sh
@@ -100,6 +100,10 @@ Comment=${DISPLAY_NAME} AppImage
 Categories=Utility;
 EOF
 
+# Include AppStream metadata to avoid appimagetool warnings
+mkdir -p ${APPDIR}/usr/share/metainfo
+cp io.github.gpt_transcribe.metainfo.xml ${APPDIR}/usr/share/metainfo/io.github.gpt_transcribe.metainfo.xml
+
 # === AppImage erstellen ===
 echo "📦 Erstelle AppImage mit $APPIMAGETOOL ..."
 ./$APPIMAGETOOL ${APPDIR} ${OUTPUT_APPIMAGE}
@@ -108,10 +112,10 @@ echo "✅ Fertig: AppImage erstellt unter ${OUTPUT_APPIMAGE}"
 
 # === Flatpak erstellen ===
 echo "📦 Erstelle Flatpak ..."
-# Ensure the Tkinter SDK extension is installed so flatpak-builder can use it
-if ! flatpak info org.freedesktop.Sdk.Extension.python3-tkinter//23.08 >/dev/null 2>&1; then
-    echo "⬇️  Installiere python3-tkinter Flatpak-Erweiterung ..."
-    flatpak install -y flathub org.freedesktop.Sdk.Extension.python3-tkinter//23.08
+# Ensure the Python SDK extension is installed so flatpak-builder can use it
+if ! flatpak info org.freedesktop.Sdk.Extension.python3//23.08 >/dev/null 2>&1; then
+    echo "⬇️  Installiere python3 Flatpak-Erweiterung ..."
+    flatpak install -y flathub org.freedesktop.Sdk.Extension.python3//23.08
 fi
 if [ "$DISABLE_CACHE" = "1" ]; then
     echo "⚠️  Cache deaktiviert – 'Pruning cache' wird übersprungen"

--- a/io.github.gpt_transcribe.yaml
+++ b/io.github.gpt_transcribe.yaml
@@ -3,13 +3,13 @@ runtime: org.freedesktop.Platform
 runtime-version: "23.08"
 sdk: org.freedesktop.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.python3-tkinter
+  - org.freedesktop.Sdk.Extension.python3
 command: gpt_transcribe
 finish-args:
   - --share=network
   - --socket=x11
-  - --env=PYTHONPATH=/app/lib/python3.11/site-packages:/usr/lib/sdk/python3-tkinter/lib/python3.11/site-packages
-  - --env=LD_LIBRARY_PATH=/usr/lib/sdk/python3-tkinter/lib
+  - --env=PYTHONPATH=/app/lib/python3.11/site-packages:/usr/lib/sdk/python3/lib/python3.11/site-packages
+  - --env=LD_LIBRARY_PATH=/usr/lib/sdk/python3/lib
 modules:
   - name: python-deps
     buildsystem: simple
@@ -17,8 +17,8 @@ modules:
       build-args:
         - --share=network
       env:
-        PYTHONPATH: /app/lib/python3.11/site-packages:/usr/lib/sdk/python3-tkinter/lib/python3.11/site-packages
-        LD_LIBRARY_PATH: /usr/lib/sdk/python3-tkinter/lib
+        PYTHONPATH: /app/lib/python3.11/site-packages:/usr/lib/sdk/python3/lib/python3.11/site-packages
+        LD_LIBRARY_PATH: /usr/lib/sdk/python3/lib
     build-commands:
       - pip3 install --no-cache-dir --prefix=/app -r requirements.txt
     sources:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ audioop-lts; python_version >= "3.13"
 reportlab
 
 openai-whisper
+tensorboard


### PR DESCRIPTION
## Summary
- use `org.freedesktop.Sdk.Extension.python3` in Flatpak manifest and build script to avoid missing extension error
- bundle AppStream metadata into AppImage build
- include `tensorboard` requirement to satisfy PyInstaller torch hook

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6891dc6a9d848333a1bd375c7a8d64ca