### PR TITLE
Remove obsolete Flatpak Python extension

### DIFF
--- a/build_appimage.sh
+++ b/build_appimage.sh
@@ -112,11 +112,7 @@ echo "✅ Fertig: AppImage erstellt unter ${OUTPUT_APPIMAGE}"
 
 # === Flatpak erstellen ===
 echo "📦 Erstelle Flatpak ..."
-# Ensure the Python SDK extension is installed so flatpak-builder can use it
-if ! flatpak info org.freedesktop.Sdk.Extension.python3//23.08 >/dev/null 2>&1; then
-    echo "⬇️  Installiere python3 Flatpak-Erweiterung ..."
-    flatpak install -y flathub org.freedesktop.Sdk.Extension.python3//23.08
-fi
+# Python support is provided by org.freedesktop.Sdk; no extra extension is needed
 if [ "$DISABLE_CACHE" = "1" ]; then
     echo "⚠️  Cache deaktiviert – 'Pruning cache' wird übersprungen"
     flatpak-builder \

--- a/io.github.gpt_transcribe.yaml
+++ b/io.github.gpt_transcribe.yaml
@@ -2,23 +2,19 @@ app-id: io.github.gpt_transcribe
 runtime: org.freedesktop.Platform
 runtime-version: "23.08"
 sdk: org.freedesktop.Sdk
-sdk-extensions:
-  - org.freedesktop.Sdk.Extension.python3
 command: gpt_transcribe
 finish-args:
   - --share=network
   - --socket=x11
-  - --env=PYTHONPATH=/app/lib/python3.11/site-packages:/usr/lib/sdk/python3/lib/python3.11/site-packages
-  - --env=LD_LIBRARY_PATH=/usr/lib/sdk/python3/lib
+  - --env=PYTHONPATH=/app/lib/python3.11/site-packages
 modules:
   - name: python-deps
     buildsystem: simple
     build-options:
-      build-args:
-        - --share=network
-      env:
-        PYTHONPATH: /app/lib/python3.11/site-packages:/usr/lib/sdk/python3/lib/python3.11/site-packages
-        LD_LIBRARY_PATH: /usr/lib/sdk/python3/lib
+        build-args:
+          - --share=network
+        env:
+          PYTHONPATH: /app/lib/python3.11/site-packages
     build-commands:
       - pip3 install --no-cache-dir --prefix=/app -r requirements.txt
     sources:


### PR DESCRIPTION
## Summary
- drop org.freedesktop.Sdk.Extension.python3 from Flatpak manifest
- rely on org.freedesktop.Sdk's built-in Python and simplify PYTHONPATH
- remove extension installation step from build script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6891e01e81348333b906472a3bbd0e52