### PR TITLE
Use packages directory for dependencies and english comments

### DIFF
--- a/build_windows.bat
+++ b/build_windows.bat
@@ -4,7 +4,8 @@ REM Build standalone executable and Inno Setup installer for gpt_transcribe
 pip install -r requirements.txt || goto :error
 pip install pyinstaller || goto :error
 
-pyinstaller gui.py --name gpt_transcribe --noconsole --onefile --add-data "config.template.cfg;." --add-data "summary_prompt.txt;." --add-data "README.md;." --icon logo/logo.ico || goto :error
+REM include Whisper assets like mel_filters.npz so transcription works in the packaged app
+pyinstaller gui.py --name gpt_transcribe --noconsole --onefile --collect-data whisper --add-data "config.template.cfg;." --add-data "summary_prompt.txt;." --add-data "README.md;." --icon logo/logo.ico || goto :error
 
 iscc gpt_transcribe.iss
 goto :eof

--- a/gpt_transcribe.iss
+++ b/gpt_transcribe.iss
@@ -1,5 +1,5 @@
 ; -------------------------------------------------------------
-; GPT Transcribe – Installer (optimierte Version)
+; GPT Transcribe – Installer (optimized version)
 ; -------------------------------------------------------------
 #define MyAppName     "GPT Transcribe"
 #define MyAppVersion  "v0.2-beta"
@@ -7,7 +7,7 @@
 #define MyAppExeName  "gpt_transcribe.exe"
 
 [Setup]
-; eindeutige GUID – doppelte Klammern = {{}}
+; unique GUID – double braces = {{}}
 AppId={{EC8F017A-D72C-47EE-92FD-E1FC4310873C}}
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
@@ -15,19 +15,19 @@ AppPublisher={#MyAppPublisher}
 DefaultDirName={autopf}\{#MyAppName}
 UninstallDisplayIcon={app}\{#MyAppExeName}
 
-; 64-Bit-Installationsmodus forcieren (x64 & Win 11 ARM)
+; force 64-bit installation mode (x64 & Win 11 ARM)
 ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
 
 DisableProgramGroupPage=yes
 LicenseFile=LICENSE
-; Hinweis: Passe den Pfad an, falls deine LICENSE woanders liegt.
+; Note: adjust the path if your LICENSE resides elsewhere.
 PrivilegesRequiredOverridesAllowed=dialog
 OutputBaseFilename=gpt_transcribe_install
 SolidCompression=yes
 WizardStyle=modern
 SetupIconFile=logo\logo.ico             
-; <- falls nötig anpassen
+; adjust if necessary
 OutputDir=dist
 
 [Languages]
@@ -38,17 +38,17 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; \
       GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-; Haupt-Executable
+; main executable
 Source: "dist\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
 
-; ffmpeg-Binaries gebündelt in Unterordner „ffmpeg“
+; ffmpeg binaries bundled in subfolder "ffmpeg"
 Source: "packages\ffmpeg\*.exe"; DestDir: "{app}\ffmpeg"; \
         Flags: ignoreversion recursesubdirs createallsubdirs
 
 ; -------------------------------------------------------------
 [Environment]
-; Installationspfad der ffmpeg-Binaries systemweit an PATH anhängen
-; Flags:  system = HKLM,  setenv = sofort wirksam,  uninsdeletevalue = sauber entfernen
+; add ffmpeg binaries folder to system PATH
+; Flags:  system = HKLM,  setenv = effective immediately,  uninsdeletevalue = remove cleanly
 Name: "Path"; Value: "{app}\ffmpeg"; \
       Flags: system setenv expandsz uninsdeletevalue
 
@@ -66,4 +66,4 @@ Filename: "{app}\{#MyAppExeName}"; \
           Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; \
           Flags: nowait postinstall skipifsilent
 
-; Kein eigener [Code]-Abschnitt mehr nötig – PATH-Handling läuft über [Environment]
+; no separate [Code] section needed – PATH handling is done in [Environment]


### PR DESCRIPTION
## Summary
- ensure build script downloads appimagetool and ffmpeg into git-ignored `packages/`
- generate AppImage and Flatpak artifacts inside `dist`
- translate build and installer comments to English
- install `python3-tk` when missing so Tkinter GUI works
- pass `--export-args="--no-prune"` to `flatpak-builder` to skip slow repository pruning
- include Whisper assets in the Windows build so local transcription works

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6891f2c0b74c8333a7fc47ad9e70af99