### PR TITLE
Include Whisper assets in Linux and macOS builds

### DIFF
--- a/build_appimage.sh
+++ b/build_appimage.sh
@@ -72,6 +72,7 @@ fi
 # === Build with PyInstaller ===
 echo "⚙️  Building the Python program with PyInstaller ..."
 pyinstaller --onefile \
+    --collect-data whisper \  # bundle Whisper's assets like mel_filters.npz
     --add-data "config.template.cfg:." \
     --add-data "summary_prompt.txt:." \
     --add-data "README.md:." \

--- a/build_macos.sh
+++ b/build_macos.sh
@@ -7,6 +7,7 @@ pip3 install -r requirements.txt
 pip3 install pyinstaller
 
 pyinstaller gui.py --name gpt_transcribe --noconsole --onefile \
+    --collect-data whisper \  # bundle Whisper's assets like mel_filters.npz
     --add-data "config.template.cfg:." \
     --add-data "summary_prompt.txt:." \
     --add-data "README.md:."


### PR DESCRIPTION
## Summary
- Ensure PyInstaller bundles Whisper's mel filter assets on Linux and macOS by collecting package data during builds.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6892414b922c8333976fbc92345a6ac5