### PR TITLE
Separate Flatpak build

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,57 +152,26 @@ creates `dist/gpt_transcribe` and `dist/gpt_transcribe.dmg`.
 
 ## Creating a Linux AppImage
 
-A helper script `build_appimage.sh` builds an AppImage with all Python dependencies.
+A helper script `build_appimage.sh` builds an AppImage with all Python dependencies and a static `ffmpeg`.
 
 ```bash
 ./build_appimage.sh
 ```
 
 The script installs packages from `requirements.txt`, installs PyInstaller and
-downloads `appimagetool` if needed. Downloaded archives and Flatpak sources are
-cached under `packages/` so they are only fetched again when missing or
-outdated. It produces both the AppImage and a `gpt_transcribe.flatpak` bundle,
-placing all artifacts in `dist/`.
+downloads `appimagetool` if needed. Downloaded archives are cached under
+`packages/` so they are only fetched again when missing or outdated. The
+resulting AppImage runs on any modern distribution and is written to `dist/`.
 
 ## Creating a Flatpak
 
-1. Install `flatpak` and `flatpak-builder` on your system.
-2. Install the Python Tkinter extension required for the GUI:
-   ```bash
-   flatpak install --user flathub org.freedesktop.Sdk.Extension.python-tkinter//23.08
-   ```
-3. Build the application with PyInstaller including the config template, prompt and README:
-   ```bash
-   pyinstaller gui.py --name gpt_transcribe --noconsole --onefile --add-data "config.template.cfg:." --add-data "summary_prompt.txt:." --add-data "README.md:." --icon logo/logo.ico
-   ```
-4. Create a Flatpak manifest `io.github.gpt_transcribe.yaml` that installs the
-   PyInstaller output. A minimal example:
-   ```yaml
-   app-id: io.github.gpt_transcribe
-   runtime: org.freedesktop.Platform
-   runtime-version: "23.08"
-   sdk: org.freedesktop.Sdk
-   command: gpt_transcribe
-   modules:
-   - name: gpt_transcribe
-    buildsystem: simple
-    build-commands:
-      - install -Dm755 gpt_transcribe/gpt_transcribe /app/bin/gpt_transcribe
-    sources:
-      - type: dir
-        path: dist
+`build_flatpak.sh` wraps `flatpak-builder` to produce a `gpt_transcribe.flatpak`
+bundle that contains all Python dependencies and a static `ffmpeg` binary.
 
-   ```
-5. Build and bundle the Flatpak:
-   ```bash
-   flatpak-builder --force-clean build-dir io.github.gpt_transcribe.yaml
-   flatpak build-bundle build-dir gpt_transcribe.flatpak io.github.gpt_transcribe
+```bash
+./build_flatpak.sh
+```
 
-   flatpak-builder --repo=repo --force-clean build-dir io.github.gpt_transcribe.yaml
-   flatpak build-bundle repo gpt_transcribe.flatpak io.github.gpt_transcribe
-   ```
-6. Install the bundle and launch the application:
-   ```bash
-   flatpak install --user gpt_transcribe.flatpak
-   flatpak run io.github.gpt_transcribe
-   ```
+Ensure `flatpak` and `flatpak-builder` are installed. The script installs the
+required Tkinter extension automatically. The generated bundle runs on any
+distribution with Flatpak support and is placed in `dist/`.

--- a/build_appimage.sh
+++ b/build_appimage.sh
@@ -19,17 +19,13 @@ APPIMAGETOOL="${PACKAGES_DIR}/appimagetool-x86_64.AppImage"
 APPIMAGETOOL_URL="https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
 FFMPEG_URL="https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz"
 FFMPEG_TAR="${PACKAGES_DIR}/ffmpeg-release-amd64-static.tar.xz"
-FLATPAK_MANIFEST="io.github.gpt_transcribe.yaml"
 DIST_DIR="./dist"
 APPDIR="${APP_NAME}.AppDir"
 OUTPUT_APPIMAGE="${DIST_DIR}/${APP_NAME}-x86_64.AppImage"
-OUTPUT_FLATPAK="${DIST_DIR}/gpt_transcribe.flatpak"
-FLATPAK_STATE_DIR="${PACKAGES_DIR}/flatpak-builder"
-DISABLE_CACHE=${DISABLE_CACHE:-0}  # set to 1 to disable flatpak-builder cache
 
 echo "📦 Starting AppImage build for $DISPLAY_NAME"
 
-mkdir -p "$PACKAGES_DIR" "$FLATPAK_STATE_DIR"
+mkdir -p "$PACKAGES_DIR"
 
 # === Check: appimagetool present? ===
 if [ ! -f "$APPIMAGETOOL" ]; then
@@ -123,38 +119,6 @@ echo "📦 Creating AppImage with $APPIMAGETOOL ..."
 ./$APPIMAGETOOL ${APPDIR} ${OUTPUT_APPIMAGE}
 
 echo "✅ Done: AppImage created at ${OUTPUT_APPIMAGE}"
-
-# === Create Flatpak ===
-echo "📦 Creating Flatpak ..."
-
-if command -v flatpak >/dev/null 2>&1; then
-    # Ensure the Tkinter extension is available
-    if ! flatpak info org.freedesktop.Sdk.Extension.python-tkinter//23.08 >/dev/null 2>&1; then
-        echo "⬇️  Installing Flatpak python-tkinter extension ..."
-        flatpak install -y --user flathub org.freedesktop.Sdk.Extension.python-tkinter//23.08
-    fi
-
-    if [ "$DISABLE_CACHE" = "1" ]; then
-        echo "⚠️  Cache disabled"
-        flatpak-builder \
-            --force-clean \
-            --delete-build-dirs \
-            --disable-cache \
-            --state-dir="${FLATPAK_STATE_DIR}" \
-            build-dir ${FLATPAK_MANIFEST}
-    else
-        echo "🗃  Using Flatpak build cache"
-        flatpak-builder \
-            --force-clean \
-            --state-dir="${FLATPAK_STATE_DIR}" \
-            build-dir ${FLATPAK_MANIFEST}
-    fi
-    flatpak build-export repo build-dir
-    flatpak build-bundle repo "${OUTPUT_FLATPAK}" io.github.gpt_transcribe
-    echo "✅ Done: Flatpak created at ${OUTPUT_FLATPAK}"
-else
-    echo "⚠️  flatpak not found; skipping Flatpak build"
-fi
 
 # === Test run (optional) ===
 echo "🚀 Starting test run of the AppImage ..."

--- a/build_flatpak.sh
+++ b/build_flatpak.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -e
+
+# Redirect all output to a log file
+LOG_DIR="./logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/build_flatpak.log"
+exec > >(tee "$LOG_FILE") 2>&1
+
+# === SETTINGS ===
+PACKAGES_DIR="./packages"
+FFMPEG_URL="https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz"
+FFMPEG_TAR="${PACKAGES_DIR}/ffmpeg-release-amd64-static.tar.xz"
+FLATPAK_MANIFEST="io.github.gpt_transcribe.yaml"
+DIST_DIR="./dist"
+OUTPUT_FLATPAK="${DIST_DIR}/gpt_transcribe.flatpak"
+FLATPAK_STATE_DIR="${PACKAGES_DIR}/flatpak-builder"
+DISABLE_CACHE=${DISABLE_CACHE:-0}  # set to 1 to disable flatpak-builder cache
+
+echo "📦 Starting Flatpak build for GPT Transcribe"
+
+mkdir -p "$PACKAGES_DIR" "$FLATPAK_STATE_DIR" "$DIST_DIR"
+
+# === Check: ffmpeg archive present? ===
+if [ ! -f "$FFMPEG_TAR" ]; then
+    echo "⬇️  Downloading ffmpeg ..."
+    curl -L -o "$FFMPEG_TAR" "$FFMPEG_URL"
+else
+    echo "✅ ffmpeg archive already present."
+fi
+
+# === Ensure flatpak tools are available ===
+if ! command -v flatpak >/dev/null 2>&1; then
+    echo "❌ flatpak not found. Please install flatpak and flatpak-builder."
+    exit 1
+fi
+if ! command -v flatpak-builder >/dev/null 2>&1; then
+    echo "❌ flatpak-builder not found. Please install flatpak-builder."
+    exit 1
+fi
+
+# Ensure the Tkinter extension is available
+if ! flatpak info org.freedesktop.Sdk.Extension.python-tkinter//23.08 >/dev/null 2>&1; then
+    echo "⬇️  Installing Flatpak python-tkinter extension ..."
+    flatpak install -y --user flathub org.freedesktop.Sdk.Extension.python-tkinter//23.08
+fi
+
+# === Build Flatpak ===
+if [ "$DISABLE_CACHE" = "1" ]; then
+    echo "⚠️  Cache disabled"
+    flatpak-builder \
+        --force-clean \
+        --delete-build-dirs \
+        --disable-cache \
+        --state-dir="${FLATPAK_STATE_DIR}" \
+        build-dir ${FLATPAK_MANIFEST}
+else
+    echo "🗃  Using Flatpak build cache"
+    flatpak-builder \
+        --force-clean \
+        --state-dir="${FLATPAK_STATE_DIR}" \
+        build-dir ${FLATPAK_MANIFEST}
+fi
+
+flatpak build-export repo build-dir
+flatpak build-bundle repo "${OUTPUT_FLATPAK}" io.github.gpt_transcribe
+
+echo "✅ Done: Flatpak created at ${OUTPUT_FLATPAK}"


### PR DESCRIPTION
## Summary
- split the Flatpak packaging logic into new `build_flatpak.sh`
- streamline `build_appimage.sh` to handle AppImage creation only
- document independent AppImage and Flatpak build scripts in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68926ad1d5448333a89069f1c4d21c9d