### PR TITLE
Ensure Flathub remote exists in Flatpak build script

### DIFF
--- a/build_flatpak.sh
+++ b/build_flatpak.sh
@@ -40,10 +40,10 @@ if ! command -v flatpak-builder >/dev/null 2>&1; then
     exit 1
 fi
 
-# Ensure the Tkinter extension is available
-if ! flatpak info org.freedesktop.Sdk.Extension.python-tkinter//23.08 >/dev/null 2>&1; then
-    echo "⬇️  Installing Flatpak python-tkinter extension ..."
-    flatpak install -y --user flathub org.freedesktop.Sdk.Extension.python-tkinter//23.08
+# Ensure Flathub remote exists (needed for potential dependencies)
+if ! flatpak remote-list | grep -q '^flathub'; then
+    echo "🔗 Adding Flathub remote ..."
+    flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 fi
 
 # === Build Flatpak ===

--- a/io.github.gpt_transcribe.yaml
+++ b/io.github.gpt_transcribe.yaml
@@ -7,7 +7,25 @@ finish-args:
   - --share=network
   - --socket=x11
   - --env=PYTHONPATH=/app/lib/python3.11/site-packages
+  - --env=TCL_LIBRARY=/app/lib/tcl8.6
+  - --env=TK_LIBRARY=/app/lib/tk8.6
 modules:
+  - name: tcl
+    buildsystem: autotools
+    subdir: tcl8.6.13/unix
+    sources:
+      - type: archive
+        url: https://downloads.sourceforge.net/project/tcl/Tcl/8.6.13/tcl8.6.13-src.tar.gz
+        sha256: 43a1fae7412f61ff11de2cfd05d28cfc3a73762f354a417c62370a54e2caf066
+  - name: tk
+    buildsystem: autotools
+    subdir: tk8.6.13/unix
+    config-opts:
+      - --with-tcl=/app/lib
+    sources:
+      - type: archive
+        url: https://prdownloads.sourceforge.net/tcl/tk8.6.13-src.tar.gz
+        sha256: 2e65fa069a23365440a3c56c556b8673b5e32a283800d8d9b257e3f584ce0675
   - name: python-deps
     buildsystem: simple
     build-options:


### PR DESCRIPTION
## Summary
- add a safeguard to build_flatpak.sh to add the Flathub remote if it is missing
- bundle Tcl/Tk into the Flatpak manifest to avoid relying on the removed python-tkinter extension

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68926efa695c8333960b4f9249e3bcc8