### PR TITLE
Save transcripts alongside summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Large MP3 or m4a files over 25 MB are automatically split into smaller chunks be
 API transcription.
 
 When executed the script prints which model is used and whether transcription happens
-locally or via the API. The summary will be written to the specified Markdown file and an accompanying
-PDF file with bookmarks.
+locally or via the API. The summary will be written to the specified Markdown file,
+the full transcript to a `.txt` file, and an accompanying PDF file with bookmarks.
 
 ## Batch transcription
 
@@ -96,10 +96,10 @@ python batch_transcribe.py --method api --language en
 to override them if needed.
 
 Summaries will be written to the `output` directory with filenames in the
-form `YYYYMMDD_NameOfTheFile.md` and a matching `.pdf` file. Successfully
-processed audio files are tracked in `processed.log` along with file size,
-duration, transcription method, transcription time and timestamp to avoid
-duplicate work.
+form `YYYYMMDD_NameOfTheFile.md`, along with matching `.txt` transcripts and
+`.pdf` files. Successfully processed audio files are tracked in
+`processed.log` along with file size, duration, transcription method,
+transcription time and timestamp to avoid duplicate work.
 
 ## GUI
 

--- a/batch_transcribe.py
+++ b/batch_transcribe.py
@@ -1,12 +1,12 @@
 """Batch process audio files from the `audio` directory.
 
 This script processes all audio files placed in the `audio` directory and
-writes summarized Markdown and PDF files to the `output` directory. After a
-file is processed its name is stored in `processed.log` to avoid duplicate
-work.
+writes summarized Markdown, transcript text, and PDF files to the `output`
+directory. After a file is processed its name is stored in `processed.log`
+to avoid duplicate work.
 
-The output filename follows the pattern ``YYYYMMDD_NameOfTheFile.md`` with a
-matching ``.pdf`` file.
+The output filename follows the pattern ``YYYYMMDD_NameOfTheFile.md`` with
+matching ``.txt`` and ``.pdf`` files.
 """
 
 from __future__ import annotations
@@ -66,7 +66,7 @@ def _process_file(
     api_key: str,
     summary_model: str,
 ) -> None:
-    """Transcribe a single audio file and write its summary."""
+    """Transcribe a single audio file and write its transcript and summary."""
     logger.info(
         f"Transcribing {path.name} using {whisper_model} via {method}..."
     )
@@ -102,11 +102,15 @@ def _process_file(
     markdown_content = f"# {heading}\n\n" + summary + "\n"
     with output_path.open("w", encoding="utf-8") as f:
         f.write(markdown_content)
+    transcript_path = OUTPUT_DIR / f"{now:%Y%m%d}_{path.stem}.txt"
+    with transcript_path.open("w", encoding="utf-8") as f:
+        f.write(transcript)
     pdf_path = OUTPUT_DIR / f"{now:%Y%m%d}_{path.stem}.pdf"
     transcribe_summary.markdown_to_pdf(markdown_content, str(pdf_path))
     _append_processed(path.name, size_bytes, duration_sec, method, elapsed)
     logger.info(f"Finished: {output_path}")
     logger.info(f"PDF saved to {pdf_path}")
+    logger.info(f"Transcript saved to {transcript_path}")
 
 
 def main() -> None:

--- a/gui.py
+++ b/gui.py
@@ -230,6 +230,9 @@ class TranscribeGUI:
                 out_md = Path(output_dir) / (Path(audio).stem + ".md")
                 with open(out_md, "w", encoding="utf-8") as f:
                     f.write(markdown_content)
+                out_txt = Path(output_dir) / (Path(audio).stem + ".txt")
+                with open(out_txt, "w", encoding="utf-8") as f:
+                    f.write(transcript)
                 pdf_path = out_md.with_suffix(".pdf")
                 transcribe_summary.markdown_to_pdf(markdown_content, str(pdf_path))
                 self.step_progress()

--- a/transcribe_summary.py
+++ b/transcribe_summary.py
@@ -312,7 +312,7 @@ def summarize(
 def main() -> None:
     logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser(
-        description="Transcribe audio with Whisper and summarize the result."
+        description="Transcribe audio with Whisper, save the transcript, and summarize the result."
     )
     parser.add_argument("audio", help="Path to the audio file to transcribe")
     parser.add_argument("output", help="Destination markdown file")
@@ -363,6 +363,11 @@ def main() -> None:
         api_key=api_key if method == "api" else None,
     )
     logger.info("Transcription complete.")
+
+    transcript_path = Path(args.output).with_suffix(".txt")
+    with open(transcript_path, "w", encoding="utf-8") as f:
+        f.write(transcript)
+    logger.info(f"Transcript written to {transcript_path}")
 
     logger.info("Summarizing transcript...")
     summary = summarize(prompt, transcript, summary_model, api_key, language)


### PR DESCRIPTION
## Summary
- Save Whisper transcription as a `.txt` file alongside the Markdown summary and PDF output.
- Write transcript files for batch and GUI modes and document new behavior.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689391c05f7c83338e03b4bea90d8946