### PR TITLE
feat: expand summary model options

### DIFF
--- a/config.template.cfg
+++ b/config.template.cfg
@@ -11,8 +11,31 @@ language = en
 [openai]
 # Your OpenAI API key. Required when method is "api".
 api_key = YOUR_API_KEY
-# Chat model used for summarizing transcripts.
+# Choose a chat model for summarizing transcripts by uncommenting one line below.
+# Only one model should remain uncommented.
+#summary_model = gpt-4o
 summary_model = gpt-4o-mini
+#summary_model = gpt-4o-mini-search-preview
+#summary_model = gpt-4o-search-preview
+#summary_model = gpt-4o-audio-preview
+#summary_model = gpt-4o-realtime-preview
+#summary_model = gpt-4.1
+#summary_model = gpt-4.1-mini
+#summary_model = gpt-4.1-nano
+#summary_model = o1
+#summary_model = o1-mini
+#summary_model = o1-pro
+#summary_model = o3
+#summary_model = o3-mini
+#summary_model = o3-mini-high
+#summary_model = o3-pro
+#summary_model = o3-deep-research
+#summary_model = o4-mini
+#summary_model = o4-mini-deep-research
+#summary_model = gpt-4.5-preview
+#summary_model = computer-use-preview
+#summary_model = codex-mini-latest
+#summary_model = gpt-image-1
 
 [whisper_api]
 # Choose an API Whisper model by uncommenting one line below.

--- a/gui.py
+++ b/gui.py
@@ -21,7 +21,31 @@ AUDIO_EXTS = [
     ("All Files", "*.*"),
 ]
 
-SUMMARY_MODELS = ["gpt-4o-mini", "gpt-4o"]
+SUMMARY_MODELS = [
+    "gpt-4o",
+    "gpt-4o-mini",
+    "gpt-4o-mini-search-preview",
+    "gpt-4o-search-preview",
+    "gpt-4o-audio-preview",
+    "gpt-4o-realtime-preview",
+    "gpt-4.1",
+    "gpt-4.1-mini",
+    "gpt-4.1-nano",
+    "o1",
+    "o1-mini",
+    "o1-pro",
+    "o3",
+    "o3-mini",
+    "o3-mini-high",
+    "o3-pro",
+    "o3-deep-research",
+    "o4-mini",
+    "o4-mini-deep-research",
+    "gpt-4.5-preview",
+    "computer-use-preview",
+    "codex-mini-latest",
+    "gpt-image-1",
+]
 
 
 def load_whisper_models(


### PR DESCRIPTION
## Summary
- expand summary model dropdown to support latest OpenAI and o-series models
- list all summary models in template config for easy selection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689460a4db108333b673b2a29fc70799